### PR TITLE
Work

### DIFF
--- a/pyverilog/testcode/decimal.v
+++ b/pyverilog/testcode/decimal.v
@@ -1,0 +1,19 @@
+//`default_nettype none
+
+module TOP(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt1;
+
+
+  always @(posedge CLK or negedge RST) begin
+    if(RST) begin
+      cnt1 <= 'd0;
+    end else begin
+      cnt1 <= cnt1 + 8'd1;
+    end
+  end
+
+
+
+endmodule
+

--- a/pyverilog/testcode/decimal2.v
+++ b/pyverilog/testcode/decimal2.v
@@ -1,0 +1,18 @@
+//`default_nettype none
+
+module TOP(CLK, RST);
+  input CLK, RST;
+  reg [7:0] cnt2;
+
+
+  always @(posedge CLK or negedge RST) begin
+    if(RST) begin
+      cnt2 <= 'd0;
+    end else begin
+      cnt2 <= cnt2 + 'd1;
+    end
+  end
+
+
+endmodule
+

--- a/pyverilog/testcode/test_sd.py
+++ b/pyverilog/testcode/test_sd.py
@@ -40,6 +40,17 @@ class TestSequenceFunctions(unittest.TestCase):
     def test_casex(self):
         self.dataflow_wrapper("casex.v")
 
+    def test_decimal(self):
+        terms, binddict = self.dataflow_wrapper("decimal.v")
+        self.assertEqual(binddict.values()[0][0].tostr(),
+        "(Bind dest:TOP.cnt1 tree:(Branch Cond:(Terminal TOP.RST) True:(IntConst 'd0) False:(Operator Plus Next:(Terminal TOP.cnt1),(IntConst 8'd1))))")
+
+    def test_decimal2(self):
+        terms, binddict = self.dataflow_wrapper("decimal2.v")
+        self.assertEqual(binddict.values()[0][0].tostr(),
+        "(Bind dest:TOP.cnt2 tree:(Branch Cond:(Terminal TOP.RST) True:(IntConst 'd0) False:(Operator Plus Next:(Terminal TOP.cnt2),(IntConst 'd1))))")
+
+
     def dataflow_wrapper(self,code_file):
 
         from optparse import OptionParser

--- a/pyverilog/vparser/lexer.py
+++ b/pyverilog/vparser/lexer.py
@@ -181,7 +181,7 @@ class VerilogLexer(object):
     signed_hex_number = '[0-9]*\'sh[0-9a-fA-Fxz][0-9a-fA-Fxz_]*'
 
     decimal_number = '[0-9]*\'d[0-9xz][0-9xz_]*' + '|' + '([0-9]*\'d)?[0-9][0-9_]*'
-    signed_decimal_number = '[0-9]*\'s(d?)[0-9xz][0-9xz_]*' + '|' + '([0-9]*\'s(d?))?[0-9][0-9_]*'
+    signed_decimal_number = '[0-9]*\'s(d?)[0-9xz][0-9xz_]*'
 
     exponent_part = r"""([eE][-+]?[0-9]+)"""
     fractional_constant = r"""([0-9]*\.[0-9]+)|([0-9]+\.)"""


### PR DESCRIPTION
modify bug: '([0-9]*\'s(d?))?[0-9][0-9_]*' changed to be  treated as unsigned decimal (Because 's' is omitted in this presentation.)