### PR TITLE
casex statement in AST code generator

### DIFF
--- a/pyverilog/ast_code_generator/codegen.py
+++ b/pyverilog/ast_code_generator/codegen.py
@@ -681,6 +681,16 @@ class ASTCodeGenerator(ConvertVisitor):
         rslt = template.render(template_dict)
         return rslt
 
+    def visit_CasexStatement(self, node):
+        filename = getfilename(node)
+        template = self.env.get_template(filename)
+        template_dict = {
+            'comp' : self.visit(node.comp),
+            'caselist' : [ self.visit(case) for case in node.caselist ],
+            }
+        rslt = template.render(template_dict)
+        return rslt
+
     def visit_Case(self, node):
         filename = getfilename(node)
         template = self.env.get_template(filename)

--- a/pyverilog/ast_code_generator/template/casexstatement.txt
+++ b/pyverilog/ast_code_generator/template/casexstatement.txt
@@ -1,0 +1,5 @@
+casex({{ comp }})
+{%- for case in caselist %}
+{{ case }}
+{%- endfor %}
+endcase


### PR DESCRIPTION
The current AST code generator does not support casex statements. This patch enables casex in AST code generator.